### PR TITLE
fix: removed header quotations

### DIFF
--- a/.changeset/late-cameras-sip.md
+++ b/.changeset/late-cameras-sip.md
@@ -1,0 +1,5 @@
+---
+"@labdigital/graphql-codegen-bruno": patch
+---
+
+Removed header quotations

--- a/packages/bruno/src/bruno.ts
+++ b/packages/bruno/src/bruno.ts
@@ -27,7 +27,7 @@ export const asBruno = async (
 	file.addElement(
 		"headers",
 		Object.entries(config.headers ?? {}).map(
-			([key, value]) => `${key}: "${value}"`,
+			([key, value]) => `${key}: ${value}`,
 		),
 	);
 


### PR DESCRIPTION
- removed quotations around custom headers. The quotes are added to the header value, which should not be the case: https://docs.usebruno.com/bru-lang/language#dictionary-block